### PR TITLE
ci: add support for py 3.13 and handle py 3.7 deprecation in ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,10 +12,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-13, macos-latest]
-        python-version: [7, 8, 9, 10, 11, 12]
+        python-version: [7, 8, 9, 10, 11, 12, 13]
         exclude:
           - python-version: 7
             os: macos-latest
+          - python-version: 7
+            os: ubuntu-latest
+        include:
+          - python-version: 7
+            os: ubuntu-22.04
 
     steps:
       - name: Checkout
@@ -62,7 +67,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [8, 12]
+        # We use the minimum and maximum supported versions of python that are not
+        # "end-of-life" or "feature": https://devguide.python.org/versions
+        python-version: [9, 13]
 
     steps:
       - name: Checkout

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,23 +5,28 @@ on: [workflow_dispatch]
 jobs:
   build_wheels:
     name: Build wheels for ${{ matrix.arch }} ${{ matrix.os }} py3.${{ matrix.python }}
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python: [7, 8, 9, 10, 11, 12]
-        os: [ubuntu, macos]
+        python: [7, 8, 9, 10, 11, 12, 13]
+        os: [ubuntu-latest, macos-latest]
         arch: [x86_64, aarch64, universal2]
         exclude:
-          - os: macos
+          - os: macos-latest
             arch: universal2
             python: 7
-          - os: ubuntu
+          - os: ubuntu-latest
             arch: universal2
-          - os: macos
+          - os: macos-latest
             arch: x86_64
-          - os: macos
+          - os: macos-latest
             arch: aarch64
+          - os: ubuntu-latest
+            python: 7
+        include:
+          - os: ubuntu-22.04
+            python: 7
 
     steps:
       - uses: actions/checkout@v4
@@ -45,7 +50,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.os }}-${{ matrix.arch }}-3${{ matrix.python }}
+          name: wheels-${{ startsWith(matrix.os, 'ubuntu') && 'ubuntu' || 'macos' }}-${{ matrix.arch }}-3${{ matrix.python }}
           path: ./wheelhouse/*.whl
 
   merge_wheels:
@@ -62,7 +67,7 @@ jobs:
   build_sdist:
     runs-on: ubuntu-latest
     env:
-      job_python_version: "3.12"
+      job_python_version: "3.13"
 
     steps:
       - name: Checkout


### PR DESCRIPTION
- [x] upgrade to ubuntu-latest runner but stay on ubuntu-22.04 for py 3.7
- [x] use py 3.9 and py 3.13 in sdist test. Make those variables in the workflow?
- [x] update release workflow to work with latest ubuntu runner too. Also add py 3.13